### PR TITLE
static implementation of editor toolbar

### DIFF
--- a/src/components/GoogleDrive.js
+++ b/src/components/GoogleDrive.js
@@ -1,15 +1,17 @@
 import React from "react";
 import Radium from "radium";
-
+import {styles} from "./styles";
 
 //TODO
 //so much
 //research google APIs
-@Radium
-export default class GoogleDrive extends React.Component {
+
+class GoogleDrive extends React.Component {
   render() {
     return(
-      <button style={[]}>Connect to Google Drive</button>
+      <button style={[styles.buttons.base, styles.buttons.googleDrive.connect2]}>Connect to Google Drive</button>
     );
   }
 }
+
+export default Radium(GoogleDrive);

--- a/src/components/More.js
+++ b/src/components/More.js
@@ -1,7 +1,7 @@
 import React from "react";
 import Menu from "react-menus";
 import Radium from "radium";
-import styles from "styles";
+import {styles} from "./styles";
 
 //function onClick(events, props, index) {};
 //function onChildClick(event, props, index) {}
@@ -31,8 +31,8 @@ const items = [
 //TODO
 //make work
 //make it so that it can collapse back down
-@Radium
-export default class More extends React.Component {
+
+class More extends React.Component {
   constructor(props) {
     super(props);
     this.state = {expanded: false};
@@ -40,9 +40,11 @@ export default class More extends React.Component {
   render() {
     return(
       <div>
-          <button style={[styles.buttons.base, styles.buttons.DropDownMenuButton]} onClick={()=>{this.setState({expanded: true});}}>More</button>
+          <button style={[styles.buttons.base, styles.buttons.more]} onClick={()=>{this.setState({expanded: true});}}>More</button>
           {this.state.expanded ? <Menu items={items} onClick={onClick}/> : null}
       </div>
     );
   }
 }
+
+export default Radium(More);

--- a/src/components/Run.js
+++ b/src/components/Run.js
@@ -1,13 +1,13 @@
 import React from "react";
 import Radium from "radium";
-import styles from "./styles";
+import {styles} from "./styles";
 
 
 //TODO
 //if clicked this.setState should make running equal to true
 //test and (probably) debug gif img within img
-@Radium
-export default class Run extends React.Component {
+
+class Run extends React.Component {
   constructor(props){
     super(props);
     this.state = {running: false};
@@ -22,7 +22,7 @@ export default class Run extends React.Component {
       );
     } else {
       return (
-        <button style={[styles.button.base, styles.buttons.run.notRunning]}>
+        <button style={[styles.buttons.base, styles.buttons.run.notRunning]}>
             Run
         </button>
       );
@@ -31,3 +31,5 @@ export default class Run extends React.Component {
 }
 
 Run.propTypes = {gif: React.PropTypes.string};
+
+export default Radium(Run);

--- a/src/components/Stop.js
+++ b/src/components/Stop.js
@@ -1,11 +1,8 @@
 import React from "react";
 import Radium from "radium";
-import styles from "./styles";
+import {styles} from "./styles";
 
-//TODO
-//test
-@Radium
-export default class Stop extends React.Component {
+class Stop extends React.Component {
   render() {
     if (this.state.running) {
       return (
@@ -16,10 +13,12 @@ export default class Stop extends React.Component {
       );
     } else {
       return (
-        <button style={[styles.button.base, styles.buttons.stop.notRunning]}>
+        <button style={[styles.buttons.base, styles.buttons.stop.notRunning]}>
             Stop
         </button>
       );
     }
   }
 }
+
+export default Radium(Stop);

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -4,22 +4,22 @@ import Stop from "./Stop";
 import GoogleDrive from "./GoogleDrive";
 import More from "./More";
 import Run from "./Run";
-import styles from "./styles";
+import {styles} from "./styles";
 
-@Radium
-export default class Toolbar extends React.Component {
+class Toolbar extends React.Component {
   render() {
     return (
       <div style={styles.toolbar}>
           <a href="https://code.pyret.org/"><img style={styles.logo} src={this.props.logo}/></a>
-          <More/>
-          <Run/>
-          <Stop/>
           <GoogleDrive/>
+          <More/>
+          <Stop/>
+          <Run/>
       </div>
     );
   } 
 }
 
 Toolbar.propTypes = {logo: React.PropTypes.string};
- //would this go here or in Run.js?
+
+export default Radium(Toolbar);

--- a/src/components/styles.js
+++ b/src/components/styles.js
@@ -20,10 +20,12 @@ export var styles = {
       width: 150,
       border: "none",
       fontSize:"15px", 
-      fontFamily: "sans-serif"
+      fontFamily: "sans-serif",
+      color: "white"
     },
     more: {
       width: 75.88,
+      float: "left",
       backgroundColor: "gray",
       marginLeft: "3px"
     },
@@ -39,11 +41,11 @@ export var styles = {
       }
     },
     stop:{
-      running: {
+      notRunning: {
         float: "right", 
         color: "gray"
       },
-      notRunning: {
+      running: {
         float: "right", 
         color: "gray",
         backgroundColor: "#FF0000"
@@ -51,10 +53,12 @@ export var styles = {
     },
     googleDrive: {
       connect2: {
+        float: "left",
         width: 194,
         backgroundColor: "gray"
       },
       connecting: {
+        float: "left",
         width: 194,
         backgroundColor: "gray",
         color: "#33331a"


### PR DESCRIPTION
Adjusted to Paul's diffs, styling tweaked, and debugged. Should display a static representation of the pyret-ide editor toolbar nearly identical to the original.
